### PR TITLE
Draggable auto scroll

### DIFF
--- a/src/addons/dragAndDrop/withDragAndDrop.js
+++ b/src/addons/dragAndDrop/withDragAndDrop.js
@@ -27,6 +27,8 @@ export default function withDragAndDrop(Calendar) {
 
       selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
       resizable: PropTypes.bool,
+
+      enableDragAutoScroll: PropTypes.bool,
     }
 
     static defaultProps = {
@@ -61,6 +63,7 @@ export default function withDragAndDrop(Calendar) {
           draggableAccessor: this.props.draggableAccessor,
           resizableAccessor: this.props.resizableAccessor,
           dragAndDropAction: this.state,
+          enableDragAutoScroll: this.props.enableDragAutoScroll,
         },
       }
     }

--- a/stories/DragAndDrop.js
+++ b/stories/DragAndDrop.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
-import { events, Calendar, Views, DragAndDropCalendar } from './helpers'
+import { events, Views, DragAndDropCalendar } from './helpers'
 import customComponents from './helpers/customComponents'
 
 storiesOf('Drag and Drop', module)
@@ -90,6 +90,18 @@ storiesOf('Drag and Drop', module)
         showMultiDayTimes
         onEventDrop={action('event dropped')}
         onEventResize={action('event resized')}
+      />
+    )
+  })
+  .add('draggable with auto scroll', () => {
+    return (
+      <DragAndDropCalendar
+        defaultDate={new Date()}
+        defaultView={Views.WEEK}
+        events={events}
+        onEventDrop={action('event dropped')}
+        onEventResize={action('event resized')}
+        enableDragAutoScroll
       />
     )
   })


### PR DESCRIPTION
Issue: When a calendar event is dragged at the top or bottom edge of the calendar container it does not scroll.

Implementation:
1. Added option called `enableDragAutoScroll`
2. When the event is dragged at the top or bottom edge, it updates the calendar container `scrollTop` to scroll